### PR TITLE
feat/add code logic and migrations for subscription events and details

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -7,6 +7,8 @@ import (
 	"subscritracker/pkg/application"
 	"subscritracker/pkg/auth"
 	subscription_channels "subscritracker/pkg/subscription-channels"
+	subscription_details "subscritracker/pkg/subscription-details"
+	subscription_events "subscritracker/pkg/subscription-events"
 
 	"github.com/labstack/echo/v4"
 )
@@ -54,6 +56,8 @@ func registerRoutes(app *application.App) error {
 	auth.RegisterRoutes(app)
 	account.RegisterRoutes(app)
 	subscription_channels.RegisterRoutes(app)
+	subscription_details.RegisterRoutes(app)
+	subscription_events.RegisterRoutes(app)
 
 	return nil
 }

--- a/db/migrations/20250810024741_create_subscription_details_table.down.sql
+++ b/db/migrations/20250810024741_create_subscription_details_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS subscription_details;

--- a/db/migrations/20250810024741_create_subscription_details_table.up.sql
+++ b/db/migrations/20250810024741_create_subscription_details_table.up.sql
@@ -1,0 +1,21 @@
+CREATE TABLE subscription_details (
+    id SERIAL PRIMARY KEY NOT NULL,
+    subscription_channel_id INT NOT NULL,
+    start_date DATE,
+    due_date DATE,
+    start_time TIME,
+    due_time TIME,
+    monthly_bill NUMERIC(10, 2),
+    reminder_date DATE,
+    reminder_time TIME,
+    status VARCHAR(255),
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_subscription_details_start_date ON subscription_details(start_date);
+CREATE INDEX idx_subscription_details_due_date ON subscription_details(due_date);
+CREATE INDEX idx_subscription_details_status ON subscription_details(status);
+CREATE INDEX idx_subscription_details_reminder_date ON subscription_details(reminder_date);
+CREATE INDEX idx_subscription_details_reminder_time ON subscription_details(reminder_time);
+

--- a/db/migrations/20250810024745_create_subscription_events_table.down.sql
+++ b/db/migrations/20250810024745_create_subscription_events_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS subscription_events;

--- a/db/migrations/20250810024745_create_subscription_events_table.up.sql
+++ b/db/migrations/20250810024745_create_subscription_events_table.up.sql
@@ -1,0 +1,15 @@
+CREATE TABLE subscription_events (
+    id SERIAL PRIMARY KEY,
+    subscription_details_id INT NOT NULL REFERENCES subscription_details(id),
+    account_id INT NOT NULL REFERENCES account(id),
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_subscription_events_subscription_details_id ON subscription_events(subscription_details_id);
+CREATE INDEX idx_subscription_events_account_id ON subscription_events(account_id);
+CREATE INDEX idx_subscription_events_created_at ON subscription_events(created_at);
+CREATE INDEX idx_subscription_events_updated_at ON subscription_events(updated_at);
+
+
+

--- a/db/migrations/20250812000001_add_account_id_to_subscription_details.down.sql
+++ b/db/migrations/20250812000001_add_account_id_to_subscription_details.down.sql
@@ -1,0 +1,11 @@
+-- Remove foreign key constraint
+ALTER TABLE subscription_details 
+DROP CONSTRAINT IF EXISTS fk_subscription_details_account;
+
+-- Remove unique constraint
+ALTER TABLE subscription_details 
+DROP CONSTRAINT IF EXISTS unique_account_subscription_channel;
+
+-- Remove account_id column
+ALTER TABLE subscription_details 
+DROP COLUMN IF EXISTS account_id; 

--- a/db/migrations/20250812000001_add_account_id_to_subscription_details.up.sql
+++ b/db/migrations/20250812000001_add_account_id_to_subscription_details.up.sql
@@ -1,0 +1,17 @@
+-- Add account_id column to subscription_details table
+ALTER TABLE subscription_details 
+ADD COLUMN account_id INT NOT NULL DEFAULT 1;
+
+-- Add foreign key constraint
+ALTER TABLE subscription_details 
+ADD CONSTRAINT fk_subscription_details_account 
+FOREIGN KEY (account_id) REFERENCES account(id);
+
+-- Update the unique constraint to include account_id
+-- This allows one subscription per channel per account
+ALTER TABLE subscription_details 
+DROP CONSTRAINT IF EXISTS unique_subscription_channel;
+
+ALTER TABLE subscription_details 
+ADD CONSTRAINT unique_account_subscription_channel 
+UNIQUE (account_id, subscription_channel_id); 

--- a/db/migrations/main.go
+++ b/db/migrations/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"log"
 	"os"
+	"strconv"
 	"subscritracker/pkg/utils"
 
 	"github.com/golang-migrate/migrate"
@@ -17,8 +18,15 @@ func main() {
 		log.Println("Running up migrations")
 	case "down":
 		log.Println("Running down migrations")
+	case "rollback":
+		log.Println("Rolling back latest migration")
+	case "force":
+		if len(os.Args) < 3 {
+			log.Fatal("Force command requires a version number")
+		}
+		log.Printf("Forcing database version to %s", os.Args[2])
 	default:
-		log.Fatal("Invalid direction, must be up or down")
+		log.Fatal("Invalid direction, must be up, down, rollback, or force")
 	}
 	db, databaseErr := utils.NewDatabase()
 	if databaseErr != nil {
@@ -45,6 +53,15 @@ func main() {
 		err = m.Up()
 	case "down":
 		err = m.Down()
+	case "rollback":
+		err = m.Steps(-1) // Rollback 1 step (latest migration)
+	case "force":
+		version := os.Args[2]
+		versionInt, err := strconv.Atoi(version)
+		if err != nil {
+			log.Fatalf("Invalid version number: %s", version)
+		}
+		err = m.Force(versionInt)
 	}
 
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,6 @@ require (
 require (
 	github.com/golang-migrate/migrate v3.5.4+incompatible
 	github.com/jinzhu/inflection v1.0.0 // indirect
-	github.com/labstack/echo v3.3.10+incompatible
 	github.com/puzpuzpuz/xsync/v3 v3.5.1 // indirect
 	github.com/tmthrgd/go-hex v0.0.0-20190904060850-447a3041c3bc // indirect
 	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,6 @@ github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
-github.com/labstack/echo v3.3.10+incompatible h1:pGRcYk231ExFAyoAjAfD85kQzRJCRI8bbnE7CX5OEgg=
-github.com/labstack/echo v3.3.10+incompatible/go.mod h1:0INS7j/VjnFxD4E2wkz67b8cVwCLbBmJyDaka6Cmk1s=
 github.com/labstack/echo/v4 v4.13.4 h1:oTZZW+T3s9gAu5L8vmzihV7/lkXGZuITzTQkTEhcXEA=
 github.com/labstack/echo/v4 v4.13.4/go.mod h1:g63b33BZ5vZzcIUF8AtRH40DrTlXnx4UMC8rBdndmjQ=
 github.com/labstack/gommon v0.4.2 h1:F8qTUNXgG1+6WQmqoUWnz8WiEU60mXVVw0P4ht1WRA0=

--- a/makefile
+++ b/makefile
@@ -26,8 +26,8 @@ db-migrate-down:
 
 .PHONY: db-rollback
 db-rollback:
-	@echo "Rolling back db migrations"
+	@echo "Rolling back latest migration"
 	go mod tidy
-	@go run db/migrations/main.go down
+	@go run db/migrations/main.go rollback
 	
 	

--- a/pkg/models/subscription-details.go
+++ b/pkg/models/subscription-details.go
@@ -1,0 +1,24 @@
+package models
+
+import (
+	"time"
+
+	"github.com/uptrace/bun"
+)
+
+type Subscription_Details struct {
+	bun.BaseModel         `bun:"subscription_details"`
+	ID                    int       `bun:"id,pk,autoincrement" json:"id"`
+	AccountID             int       `bun:"account_id" json:"account_id"`
+	SubscriptionChannelID int       `bun:"subscription_channel_id" json:"subscription_channel_id"`
+	StartDate             time.Time `bun:"start_date" json:"start_date"`
+	DueDate               time.Time `bun:"due_date" json:"due_date"`
+	Status                string    `bun:"status" json:"status"`
+	StartTime             time.Time `bun:"start_time" json:"start_time"`
+	DueTime               time.Time `bun:"due_time" json:"due_time"`
+	MonthlyBill           float64   `bun:"monthly_bill" json:"monthly_bill"`
+	ReminderDate          time.Time `bun:"reminder_date" json:"reminder_date"`
+	ReminderTime          time.Time `bun:"reminder_time" json:"reminder_time"`
+	CreatedAt             time.Time `bun:"created_at" json:"created_at"`
+	UpdatedAt             time.Time `bun:"updated_at" json:"updated_at"`
+}

--- a/pkg/models/subscription-events.go
+++ b/pkg/models/subscription-events.go
@@ -1,0 +1,16 @@
+package models
+
+import (
+	"time"
+
+	"github.com/uptrace/bun"
+)
+
+type Subscription_Event struct {
+	bun.BaseModel         `bun:"subscription_events"`
+	ID                    int       `json:"id" bun:",autoincrement"`
+	SubscriptionDetailsID int       `json:"subscription_details_id"`
+	AccountID             int       `json:"account_id"`
+	CreatedAt             time.Time `json:"created_at"`
+	UpdatedAt             time.Time `json:"updated_at"`
+}

--- a/pkg/subscription-channels/helper.go
+++ b/pkg/subscription-channels/helper.go
@@ -57,9 +57,9 @@ func CreateChannel(c echo.Context, channel models.Subscription_Channels) (*model
 		channel.ChannelType = "streaming"
 	}
 
-	err := app.Database.NewInsert().
+	_, err := app.Database.NewInsert().
 		Model(&channel).
-		Scan(context.Background())
+		Exec(context.Background())
 
 	if err != nil {
 		log.Println("Error creating channel: ", err)

--- a/pkg/subscription-details/handler.go
+++ b/pkg/subscription-details/handler.go
@@ -1,0 +1,70 @@
+package subscriptiondetails
+
+import (
+	"log"
+	"net/http"
+	"subscritracker/pkg/application"
+	"subscritracker/pkg/models"
+	"subscritracker/pkg/validator"
+
+	"github.com/labstack/echo/v4"
+)
+
+func PostSubscriptionDetailsHandler(c echo.Context) error {
+	accountID := c.Get("user_id").(int)
+	request, err := validator.ValidateSubscriptionDetailsRequest(c)
+	if err != nil {
+		log.Println("Error validating subscription details request:", err)
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
+	}
+
+	// Check if user already has a subscription to this channel
+	app := c.Get("app").(*application.App)
+	existingSubscription, err := CheckExistingSubscriptionByChannel(app, accountID, request.SubscriptionChannelID)
+	if err != nil {
+		log.Println("Error checking existing subscription:", err)
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": "Failed to check existing subscription"})
+	}
+
+	if existingSubscription {
+		return c.JSON(http.StatusConflict, map[string]string{"error": "You already have a subscription to this channel"})
+	}
+
+	subscriptionDetails := models.Subscription_Details{
+		AccountID:             accountID,
+		SubscriptionChannelID: request.SubscriptionChannelID,
+		Status:                request.Status,
+		MonthlyBill:           request.MonthlyBill,
+	}
+
+	// Handle optional time fields - only set if they exist
+	if request.StartDate != nil {
+		subscriptionDetails.StartDate = *request.StartDate
+	}
+	if request.DueDate != nil {
+		subscriptionDetails.DueDate = *request.DueDate
+	}
+	if request.StartTime != nil {
+		subscriptionDetails.StartTime = *request.StartTime
+	}
+	if request.DueTime != nil {
+		subscriptionDetails.DueTime = *request.DueTime
+	}
+	if request.ReminderDate != nil {
+		subscriptionDetails.ReminderDate = *request.ReminderDate
+	}
+	if request.ReminderTime != nil {
+		subscriptionDetails.ReminderTime = *request.ReminderTime
+	}
+
+	createdSubscriptionDetails, err := CreateSubscriptionDetails(c, subscriptionDetails)
+	if err != nil {
+		log.Println("Error creating subscription details:", err)
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+	return c.JSON(http.StatusCreated, createdSubscriptionDetails)
+}
+
+func GetSubscriptionDetailsHandler(c echo.Context) error {
+	return nil
+}

--- a/pkg/subscription-details/helper.go
+++ b/pkg/subscription-details/helper.go
@@ -1,0 +1,84 @@
+package subscriptiondetails
+
+import (
+	"context"
+	"errors"
+	"log"
+	"strings"
+	"time"
+
+	"subscritracker/pkg/application"
+	"subscritracker/pkg/models"
+
+	"github.com/labstack/echo/v4"
+)
+
+func CreateSubscriptionDetails(c echo.Context, subscriptionDetails models.Subscription_Details) (models.Subscription_Details, error) {
+	app := c.Get("app").(*application.App)
+
+	// Set timestamps
+	subscriptionDetails.CreatedAt = time.Now()
+	subscriptionDetails.UpdatedAt = time.Now()
+
+	_, err := app.Database.NewInsert().
+		Model(&subscriptionDetails).
+		Exec(context.Background())
+	if err != nil {
+		log.Println("Error creating subscription details:", err)
+		return models.Subscription_Details{}, err
+	}
+
+	return subscriptionDetails, nil
+}
+
+func GetSubscriptionDetailsByID(c echo.Context, id int) (models.Subscription_Details, error) {
+	app := c.Get("app").(*application.App)
+
+	subscriptionDetails := models.Subscription_Details{}
+	err := app.Database.NewSelect().
+		Model(&subscriptionDetails).
+		Where("id = ?", id).
+		Scan(context.Background())
+	if err != nil {
+		// Check if it's a "no rows" error from Bun ORM
+		if err.Error() == "sql: no rows in result set" || err.Error() == "no rows in result set" {
+			return models.Subscription_Details{}, errors.New("subscription details not found")
+		}
+		return models.Subscription_Details{}, err
+	}
+
+	return subscriptionDetails, nil
+}
+
+func CheckSubscriptionDetailsExists(c echo.Context, id int) (bool, error) {
+	_, err := GetSubscriptionDetailsByID(c, id)
+	if err != nil {
+		// If the error is "not found", return false without error
+		if err.Error() == "subscription details not found" {
+			return false, nil
+		}
+		// For other errors, return the error
+		return false, err
+	}
+
+	return true, nil
+}
+
+func CheckExistingSubscriptionByChannel(app *application.App, accountID, channelID int) (bool, error) {
+	var subscription models.Subscription_Details
+	err := app.Database.NewSelect().
+		Model(&subscription).
+		Where("account_id = ? AND subscription_channel_id = ?", accountID, channelID).
+		Limit(1).
+		Scan(context.Background())
+
+	if err != nil {
+		// Check if it's a "no rows" error
+		if strings.Contains(err.Error(), "no rows in result set") {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return true, nil
+}

--- a/pkg/subscription-details/main.go
+++ b/pkg/subscription-details/main.go
@@ -1,0 +1,12 @@
+package subscriptiondetails
+
+import (
+	"subscritracker/pkg/application"
+	"subscritracker/pkg/utils"
+)
+
+func RegisterRoutes(app *application.App) {
+	// app.Echo.GET("/v1/subscription-details", GetAllSubscriptionDetailsHandler, utils.AuthMiddleware)
+	app.Echo.GET("/v1/subscription-details/:id", GetSubscriptionDetailsHandler, utils.AuthMiddleware)
+	app.Echo.POST("/v1/subscription-details", PostSubscriptionDetailsHandler, utils.AuthMiddleware)
+}

--- a/pkg/subscription-events/handler.go
+++ b/pkg/subscription-events/handler.go
@@ -1,12 +1,10 @@
 package subscriptionevents
 
 import (
-	"fmt"
 	"net/http"
 	"subscritracker/pkg/models"
 	subscriptiondetails "subscritracker/pkg/subscription-details"
 	"subscritracker/pkg/validator"
-	"time"
 
 	"github.com/labstack/echo/v4"
 )
@@ -29,12 +27,9 @@ func PostSubscriptionEventsHandler(c echo.Context) error {
 	subscriptionEvent := models.Subscription_Event{
 		SubscriptionDetailsID: request.SubscriptionDetailsID,
 		AccountID:             request.AccountID,
-		CreatedAt:             time.Now(),
-		UpdatedAt:             time.Now(),
 	}
 
 	createdSubscriptionEvent, err := CreateSubscriptionEvent(c, subscriptionEvent)
-	fmt.Println("Created subscription event", createdSubscriptionEvent)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
 	}

--- a/pkg/subscription-events/handler.go
+++ b/pkg/subscription-events/handler.go
@@ -1,0 +1,43 @@
+package subscriptionevents
+
+import (
+	"fmt"
+	"net/http"
+	"subscritracker/pkg/models"
+	subscriptiondetails "subscritracker/pkg/subscription-details"
+	"subscritracker/pkg/validator"
+	"time"
+
+	"github.com/labstack/echo/v4"
+)
+
+func PostSubscriptionEventsHandler(c echo.Context) error {
+	request, err := validator.ValidateSubscriptionEventRequest(c)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
+	}
+
+	// Validate subscription details id exists
+	exists, err := subscriptiondetails.CheckSubscriptionDetailsExists(c, request.SubscriptionDetailsID)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+	if !exists {
+		return c.JSON(http.StatusBadRequest, map[string]string{"error": "subscription_details_id cannot be found"})
+	}
+
+	subscriptionEvent := models.Subscription_Event{
+		SubscriptionDetailsID: request.SubscriptionDetailsID,
+		AccountID:             request.AccountID,
+		CreatedAt:             time.Now(),
+		UpdatedAt:             time.Now(),
+	}
+
+	createdSubscriptionEvent, err := CreateSubscriptionEvent(c, subscriptionEvent)
+	fmt.Println("Created subscription event", createdSubscriptionEvent)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+
+	return c.JSON(http.StatusCreated, createdSubscriptionEvent)
+}

--- a/pkg/subscription-events/helper.go
+++ b/pkg/subscription-events/helper.go
@@ -1,0 +1,30 @@
+package subscriptionevents
+
+import (
+	"context"
+	"log"
+	"subscritracker/pkg/application"
+	"subscritracker/pkg/models"
+	"time"
+
+	"github.com/labstack/echo/v4"
+)
+
+func CreateSubscriptionEvent(c echo.Context, request models.Subscription_Event) (models.Subscription_Event, error) {
+	app := c.Get("app").(*application.App)
+
+	// Set timestamps
+	request.CreatedAt = time.Now()
+	request.UpdatedAt = time.Now()
+
+	_, err := app.Database.NewInsert().
+		Model(&request).
+		Exec(context.Background())
+	log.Println("Created subscription event", request)
+	log.Println("Error", err)
+	if err != nil {
+		return models.Subscription_Event{}, err
+	}
+
+	return request, nil
+}

--- a/pkg/subscription-events/helper.go
+++ b/pkg/subscription-events/helper.go
@@ -20,9 +20,8 @@ func CreateSubscriptionEvent(c echo.Context, request models.Subscription_Event) 
 	_, err := app.Database.NewInsert().
 		Model(&request).
 		Exec(context.Background())
-	log.Println("Created subscription event", request)
-	log.Println("Error", err)
 	if err != nil {
+		log.Println("Error creating subscription event:", err)
 		return models.Subscription_Event{}, err
 	}
 

--- a/pkg/subscription-events/main.go
+++ b/pkg/subscription-events/main.go
@@ -1,0 +1,12 @@
+package subscriptionevents
+
+import (
+	"subscritracker/pkg/application"
+	"subscritracker/pkg/utils"
+)
+
+func RegisterRoutes(app *application.App) {
+	// app.Echo.GET("/v1/subscription-events", GetAllSubscriptionEventsHandler, utils.AuthMiddleware)
+	// app.Echo.GET("/v1/subscription-events/:id", GetSubscriptionEventsHandler, utils.AuthMiddleware)
+	app.Echo.POST("/v1/subscription-events", PostSubscriptionEventsHandler, utils.AuthMiddleware)
+}

--- a/pkg/utils/jwt.go
+++ b/pkg/utils/jwt.go
@@ -21,7 +21,7 @@ func GenerateJWT(userId int, email string) (string, error) {
 		UserId: userId,
 		Email:  email,
 		RegisteredClaims: jwt.RegisteredClaims{
-			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour * 24)),
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour * 24 * 7)),
 			IssuedAt:  jwt.NewNumericDate(time.Now()),
 			NotBefore: jwt.NewNumericDate(time.Now()),
 		},

--- a/pkg/validator/subscription-details.go
+++ b/pkg/validator/subscription-details.go
@@ -1,0 +1,102 @@
+package validator
+
+import (
+	"errors"
+	"time"
+
+	"github.com/labstack/echo/v4"
+)
+
+type SubscriptionDetailsRequest struct {
+	SubscriptionChannelID int     `json:"subscription_channel_id" form:"subscription_channel_id" validate:"required"`
+	StartDate             string  `json:"start_date" form:"start_date"`
+	DueDate               string  `json:"due_date" form:"due_date"`
+	Status                string  `json:"status" form:"status"`
+	StartTime             string  `json:"start_time" form:"start_time"`
+	DueTime               string  `json:"due_time" form:"due_time"`
+	MonthlyBill           float64 `json:"monthly_bill" form:"monthly_bill"`
+	ReminderDate          string  `json:"reminder_date" form:"reminder_date"`
+	ReminderTime          string  `json:"reminder_time" form:"reminder_time"`
+}
+
+// ParsedSubscriptionDetails contains the parsed time.Time values
+type ParsedSubscriptionDetails struct {
+	SubscriptionChannelID int
+	StartDate             *time.Time
+	DueDate               *time.Time
+	Status                string
+	StartTime             *time.Time
+	DueTime               *time.Time
+	MonthlyBill           float64
+	ReminderDate          *time.Time
+	ReminderTime          *time.Time
+}
+
+func ValidateSubscriptionDetailsRequest(c echo.Context) (*ParsedSubscriptionDetails, error) {
+	var request SubscriptionDetailsRequest
+	if err := c.Bind(&request); err != nil {
+		return nil, err
+	}
+
+	parsed := &ParsedSubscriptionDetails{
+		SubscriptionChannelID: request.SubscriptionChannelID,
+		Status:                request.Status,
+		MonthlyBill:           request.MonthlyBill,
+	}
+
+	// Parse StartDate
+	if request.StartDate != "" {
+		if t, err := time.Parse("2006-01-02", request.StartDate); err == nil {
+			parsed.StartDate = &t
+		} else {
+			return nil, errors.New("invalid start_date format. Expected YYYY-MM-DD")
+		}
+	}
+
+	// Parse DueDate
+	if request.DueDate != "" {
+		if t, err := time.Parse("2006-01-02", request.DueDate); err == nil {
+			parsed.DueDate = &t
+		} else {
+			return nil, errors.New("invalid due_date format. Expected YYYY-MM-DD")
+		}
+	}
+
+	// Parse StartTime
+	if request.StartTime != "" {
+		if t, err := time.Parse("15:04", request.StartTime); err == nil {
+			parsed.StartTime = &t
+		} else {
+			return nil, errors.New("invalid start_time format. Expected HH:MM")
+		}
+	}
+
+	// Parse DueTime
+	if request.DueTime != "" {
+		if t, err := time.Parse("15:04", request.DueTime); err == nil {
+			parsed.DueTime = &t
+		} else {
+			return nil, errors.New("invalid due_time format. Expected HH:MM")
+		}
+	}
+
+	// Parse ReminderDate
+	if request.ReminderDate != "" {
+		if t, err := time.Parse("2006-01-02", request.ReminderDate); err == nil {
+			parsed.ReminderDate = &t
+		} else {
+			return nil, errors.New("invalid reminder_date format. Expected YYYY-MM-DD")
+		}
+	}
+
+	// Parse ReminderTime
+	if request.ReminderTime != "" {
+		if t, err := time.Parse("15:04", request.ReminderTime); err == nil {
+			parsed.ReminderTime = &t
+		} else {
+			return nil, errors.New("invalid reminder_time format. Expected HH:MM")
+		}
+	}
+
+	return parsed, nil
+}

--- a/pkg/validator/subscription-event.go
+++ b/pkg/validator/subscription-event.go
@@ -1,0 +1,57 @@
+package validator
+
+import (
+	"errors"
+	"strconv"
+
+	"github.com/labstack/echo/v4"
+)
+
+type SubscriptionEventRequest struct {
+	SubscriptionDetailsID int `json:"subscription_details_id"`
+	AccountID             int `json:"account_id"`
+}
+
+func ValidateSubscriptionEventRequest(c echo.Context) (SubscriptionEventRequest, error) {
+	request := SubscriptionEventRequest{}
+
+	// Try to bind JSON first
+	if err := c.Bind(&request); err == nil {
+		// JSON binding succeeded, validate the values
+		if request.SubscriptionDetailsID <= 0 {
+			return SubscriptionEventRequest{}, errors.New("subscription_details_id must be a positive integer")
+		}
+		if request.AccountID <= 0 {
+			return SubscriptionEventRequest{}, errors.New("account_id must be a positive integer")
+		}
+		return request, nil
+	}
+
+	// If JSON binding failed, try form data
+	subscriptionDetailsIDStr := c.FormValue("subscription_details_id")
+	accountIDStr := c.FormValue("account_id")
+
+	if subscriptionDetailsIDStr == "" {
+		return SubscriptionEventRequest{}, errors.New("subscription_details_id is required")
+	}
+
+	if accountIDStr == "" {
+		return SubscriptionEventRequest{}, errors.New("account_id is required")
+	}
+
+	// Parse string values to integers
+	subscriptionDetailsID, err := strconv.Atoi(subscriptionDetailsIDStr)
+	if err != nil {
+		return SubscriptionEventRequest{}, errors.New("subscription_details_id must be a valid integer")
+	}
+
+	accountID, err := strconv.Atoi(accountIDStr)
+	if err != nil {
+		return SubscriptionEventRequest{}, errors.New("account_id must be a valid integer")
+	}
+
+	request.SubscriptionDetailsID = subscriptionDetailsID
+	request.AccountID = accountID
+
+	return request, nil
+}


### PR DESCRIPTION
- Create migrations for subscription-events and subscription-details
- Create code logic to deal with events and details

After a successful creation, details are posted, followed by events. Events are being used to track the number of subscriptions per account.


Todo: complete `GetSubscriptionDetailsHandler` and other routes for events and details